### PR TITLE
[GMSOFT-1212] adding first script

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Install MySQL python library:
 ```
 $ sudo yum install mysql-connector-python
 ```
-- For Ubuntu
+- For Ubuntu:
 ```
 $ sudo apt-get install python-mysqldb
 ```

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ No argument needed, everything will be prompt
 
 ### Real usage for your needs
 
-This script has been created for our company instances of bugzilla an JIRA so some part must be changed when you use it:
+This script has been created for our company instances of bugzilla and JIRA so some part must be changed when you use it:
 - We use our zendesk instance name to keep our zendesk links in our jira issues
 - The tables requested might change if you created personnal bugzilla fields.
 - The elements of the description might change for the same reason

--- a/README.md
+++ b/README.md
@@ -1,2 +1,63 @@
 # bugzilla_to_jira
 Python script to migrate your Bugzilla ticket to Jira
+
+### Installation
+
+Clone the repo, or download the raw bugToJira.py
+
+### Usage
+
+Run: ```$ ./bugToJira.py```
+
+No argument needed, everything will be prompt
+
+### Real usage for your needs
+
+This script has been created for our company instances of bugzilla an JIRA so some part must be changed when you use it:
+- We use our zendesk instance name to keep our zendesk links in our jira issues
+- The tables requested might change if you created personnal bugzilla fields.
+- The elements of the description might change for the same reason
+- If you want to use custom fields in jira to store some values, you'll have to set them up like it is in the script
+```issue_dict.update({'customfield_10600': {'value': issue_severity}, 'customfield_10601': {'value': issue_status}})```
+- The ```Android Version``` we use in our script is a kind of a trick to keep a n to n table in a list, in the description.
+
+### All ```bugToJira.py``` comments in a row
+
+```
+# Functions!
+
+# Get a value from the user
+
+# Script!
+
+# Get Bugzilla DB info and connect
+# Get JIRA info and connect
+# Get Zendesk instance to create cool links
+
+# Load bugs from bugzilla
+# We will store a dict with bugzilla {bug id: jira issue} to, then, add android versions, comments and attachements
+
+# Create JIRA issues from bugs (without comments, attachements and Android versions)
+
+# Add Android versions for each issues
+# Create a dict with bug_id | android versions
+# Loop on android versions table to fill the dict
+# Loop on each jira issue
+    # Get the description from bug_id_jira_id_dict and update the android version with the one stored in bug_id_android_versions_dict
+    # push the result on jira
+
+# Add Attachements to issues
+# Loop on attachement table
+    # Reopen the file in 'rb' as JIRA really want that
+    # Add attachement to jira
+    # Add a comment in jira issue with a description of the attachement
+
+# Add comments to issues
+# Create an array to list the issue who already have a description, as the first bugzilla comment will be the JIRA description
+# Loop on comments table
+    # If first comment
+        # Get the description from bug_id_jira_id_dict and update the description with the one stored in row_comments
+        # Push the result on jira
+    # Else
+        # Add the comment as... comment in the issue
+```

--- a/README.md
+++ b/README.md
@@ -5,6 +5,20 @@ Python script to migrate your Bugzilla ticket to Jira
 
 Clone the repo, or download the raw bugToJira.py
 
+Install JIRA python library
+```$ sudo pip install jira```
+
+Install MySQL python library:
+
+- For Fedora:
+```
+$ sudo yum install mysql-connector-python
+```
+- For Ubuntu
+```
+$ sudo apt-get install python-mysqldb
+```
+
 ### Usage
 
 Run: ```$ ./bugToJira.py```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ This script has been created for our company instances of bugzilla an JIRA so so
 # Get Zendesk instance to create cool links
 
 # Load bugs from bugzilla
+# Load android versions
+# Load attachments
+# Load comments
 # We will store a dict with bugzilla {bug id: jira issue} to, then, add android versions, comments and attachments
 
 # Create JIRA issues from bugs (without comments, attachments and Android versions)

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ This script has been created for our company instances of bugzilla an JIRA so so
 # Get Zendesk instance to create cool links
 
 # Load bugs from bugzilla
-# We will store a dict with bugzilla {bug id: jira issue} to, then, add android versions, comments and attachements
+# We will store a dict with bugzilla {bug id: jira issue} to, then, add android versions, comments and attachments
 
-# Create JIRA issues from bugs (without comments, attachements and Android versions)
+# Create JIRA issues from bugs (without comments, attachments and Android versions)
 
 # Add Android versions for each issues
 # Create a dict with bug_id | android versions
@@ -60,11 +60,11 @@ This script has been created for our company instances of bugzilla an JIRA so so
     # Get the description from bug_id_jira_id_dict and update the android version with the one stored in bug_id_android_versions_dict
     # push the result on jira
 
-# Add Attachements to issues
-# Loop on attachement table
+# Add attachments to issues
+# Loop on attachment table
     # Reopen the file in 'rb' as JIRA really want that
-    # Add attachement to jira
-    # Add a comment in jira issue with a description of the attachement
+    # Add attachment to jira
+    # Add a comment in jira issue with a description of the attachment
 
 # Add comments to issues
 # Create an array to list the issue who already have a description, as the first bugzilla comment will be the JIRA description

--- a/bugToJira.py
+++ b/bugToJira.py
@@ -1,4 +1,4 @@
-#!/bin/python3
+#!/usr/bin/env python3
 
 import getpass
 import os

--- a/bugToJira.py
+++ b/bugToJira.py
@@ -12,19 +12,19 @@ JIRA_LABEL = 'From_Bugzilla'
 # Functions!
 
 # Get a value from the user
-def get_value(question, is_mandatory = False, default_value = '', is_password = False ):
+def get_value(question, is_mandatory=False, default_value='', is_password=False):
     value = ''
     is_value_ok = False
-    while (not is_value_ok):
-        if (is_password):
+    while not is_value_ok:
+        if is_password:
             value = getpass.getpass(question)
         else:
             value = input(question)
         
-        if (value == '' and default_value != ''):
+        if value == '' and default_value != '':
             value = default_value
         
-        if (value == '' and is_mandatory):
+        if value == '' and is_mandatory:
             print("This value is mandatory, again...")
         else:
             is_value_ok = True
@@ -35,28 +35,28 @@ def get_value(question, is_mandatory = False, default_value = '', is_password = 
 print("\nWelcome to this awesome script which will migrate your bugzilla tickets to your JIRA instance. please give us all your personnal informations.\n")
 
 # Get Bugzilla DB info and connect
-mysql_host = get_value("MySQL host [localhost]: ", default_value = 'localhost')
-mysql_user = get_value("MySQL user [root]: ", default_value = 'root')
-mysql_password = get_value("MySQL password [root]: ", default_value = 'root', is_password = True)
-mysql_database = get_value("MySQL database table [bugzilla]: ", default_value = 'bugzilla')
+mysql_host = get_value("MySQL host [localhost]: ", default_value='localhost')
+mysql_user = get_value("MySQL user [root]: ", default_value='root')
+mysql_password = get_value("MySQL password [root]: ", default_value='root', is_password=True)
+mysql_database = get_value("MySQL database table [bugzilla]: ", default_value='bugzilla')
 
 print("\nConnecting to your MySQL database...")
 mysql_conn = mysql.connector.connect(host=mysql_host, user=mysql_user,password=mysql_password, database=mysql_database)
 print("Connected.\n")
 
 # Get JIRA info and connect
-jira_username = get_value("JIRA username: ", is_mandatory = True)
-jira_password = get_value("JIRA password: ", is_mandatory = True, is_password = True)
-jira_instance = get_value("JIRA instance: https://[yourJiraInstance].atlassian.net: ", is_mandatory = True)
+jira_username = get_value("JIRA username: ", is_mandatory=True)
+jira_password = get_value("JIRA password: ", is_mandatory=True, is_password=True)
+jira_instance = get_value("JIRA instance: https://[yourJiraInstance].atlassian.net: ", is_mandatory=True)
 jira_project = get_value("JIRA project [TEST]: ", default_value = 'TEST')
 
 print("\nConnecting to your JIRA instance...")
-jira_options = { 'server': 'https://' + jira_instance + '.atlassian.net' }
+jira_options = {'server': 'https://' + jira_instance + '.atlassian.net'}
 jira = JIRA(jira_options, basic_auth=(jira_username, jira_password))
 print("Connected.\n")
 
 # Get Zendesk instance to create cool links
-zendesk_instance = get_value("Zendesk instance: https://[yourZendeskInstance].zendesk.com: ", is_mandatory = True)
+zendesk_instance = get_value("Zendesk instance: https://[yourZendeskInstance].zendesk.com: ", is_mandatory=True)
 
 # Load bugs from bugzilla
 print("\nLoading bugs...")
@@ -137,9 +137,9 @@ for row_bug in rows_bugs:
                         '[Zendesk ticket]: https://' + zendesk_instance + '.zendesk.com/agent/tickets/' + row_bug[13] + '\n' + \
                         '[Description]:\n' + DESCRIPTION_KEY
     issue_priority = row_bug[6].replace("Normal", "Medium").replace("---", "Medium")
-    issue_dict = {'project':jira_project, 'summary': issue_summary, 'description': issue_description, 'priority': {'name': issue_priority}, "labels": [JIRA_LABEL] }
+    issue_dict = {'project':jira_project, 'summary': issue_summary, 'description': issue_description, 'priority': {'name': issue_priority}, "labels": [JIRA_LABEL]}
     issue_type = 'Story'
-    if (row_bug[11] in ['Ticket', 'Problem']):
+    if row_bug[11] in ['Ticket', 'Problem']:
         issue_type = 'Bug'
         issue_severity = row_bug[1].replace("---", "normal").replace("-", " ")
         issue_status = row_bug[2].replace("---", "TO_CHECK").replace("-", " ").replace("_", " ").capitalize()
@@ -156,13 +156,13 @@ bug_id_android_versions_dict = {}
 # Loop on android versions table to fill the dict
 for row_android_version in rows_android_version:
     value = bug_id_android_versions_dict.get(row_android_version[0])
-    if (value == None):
+    if value == None:
         bug_id_android_versions_dict.update({row_android_version[0]: row_android_version[1]})
     else:
         bug_id_android_versions_dict.update({row_android_version[0]: value + ", " + row_android_version[1]})
 # Loop on each jira issue
 for bug in bug_id_jira_issue_dict:
-    if (bug not in bug_id_android_versions_dict):
+    if bug not in bug_id_android_versions_dict:
         continue
     # Get the description from bug_id_jira_id_dict and update the android version with the one stored in bug_id_android_versions_dict
     issue = bug_id_jira_issue_dict.get(bug)
@@ -176,7 +176,7 @@ for bug in bug_id_jira_issue_dict:
 print("\nAdding attachements to JIRA issues...\n")
 # Loop on attachement table
 for row_attachement in rows_attachements:
-    if (row_attachement[0] not in bug_id_jira_issue_dict):
+    if row_attachement[0] not in bug_id_jira_issue_dict:
         continue
     issue = bug_id_jira_issue_dict.get(row_attachement[0])
     filename = row_attachement[1]
@@ -201,11 +201,11 @@ print("\nAdding comments to JIRA issues...\n")
 issues_with_description = []
 # Loop on comments table
 for row_comments in rows_comments:
-    if (row_comments[0] not in bug_id_jira_issue_dict or row_comments[3] == ''):
+    if row_comments[0] not in bug_id_jira_issue_dict or row_comments[3] == '':
         continue
     issue = bug_id_jira_issue_dict.get(row_comments[0])
     long_comment = str(row_comments[2]) + ", by " + row_comments[1] + ":\n" + row_comments[3]
-    if (issue.key not in issues_with_description):
+    if issue.key not in issues_with_description:
         # Get the description from bug_id_jira_id_dict and update the description with the one stored in row_comments
         description = issue.fields.description
         description = description.replace(DESCRIPTION_KEY, long_comment)

--- a/bugToJira.py
+++ b/bugToJira.py
@@ -11,8 +11,8 @@ JIRA_LABEL = 'From_Bugzilla'
 
 # Functions!
 
-# Get a value from the user
 def get_value(question, is_mandatory=False, default_value='', is_password=False):
+    """Get a value from the user"""
     value = ''
     is_value_ok = False
     while not is_value_ok:

--- a/bugToJira.py
+++ b/bugToJira.py
@@ -1,0 +1,221 @@
+#!/bin/python3
+
+import getpass
+import os
+from jira import JIRA
+import mysql.connector
+
+ANDROID_VERSION_KEY = '[ANDROID_VERSION_KEY]'
+DESCRIPTION_KEY = '[DESCRIPTION_KEY]'
+JIRA_LABEL = 'From_Bugzilla'
+
+# Functions!
+
+# Get a value from the user
+def get_value(question, is_mandatory = False, default_value = '', is_password = False ):
+    value = ''
+    is_value_ok = False
+    while (not is_value_ok):
+        if (is_password):
+            value = getpass.getpass(question)
+        else:
+            value = input(question)
+        
+        if (value == '' and default_value != ''):
+            value = default_value
+        
+        if (value == '' and is_mandatory):
+            print("This value is mandatory, again...")
+        else:
+            is_value_ok = True
+    return value
+
+# Script!
+
+print("\nWelcome to this awesome script which will migrate your bugzilla tickets to your JIRA instance. please give us all your personnal informations.\n")
+
+# Get Bugzilla DB info and connect
+mysql_host = get_value("MySQL host [localhost]: ", default_value = 'localhost')
+mysql_user = get_value("MySQL user [root]: ", default_value = 'root')
+mysql_password = get_value("MySQL password [root]: ", default_value = 'root', is_password = True)
+mysql_database = get_value("MySQL database table [bugzilla]: ", default_value = 'bugzilla')
+
+print("\nConnecting to your MySQL database...")
+mysql_conn = mysql.connector.connect(host=mysql_host, user=mysql_user,password=mysql_password, database=mysql_database)
+print("Connected.\n")
+
+# Get JIRA info and connect
+jira_username = get_value("JIRA username: ", is_mandatory = True)
+jira_password = get_value("JIRA password: ", is_mandatory = True, is_password = True)
+jira_instance = get_value("JIRA instance: https://[yourJiraInstance].atlassian.net: ", is_mandatory = True)
+jira_project = get_value("JIRA project [TEST]: ", default_value = 'TEST')
+
+print("\nConnecting to your JIRA instance...")
+jira_options = { 'server': 'https://' + jira_instance + '.atlassian.net' }
+jira = JIRA(jira_options, basic_auth=(jira_username, jira_password))
+print("Connected.\n")
+
+# Get Zendesk instance to create cool links
+zendesk_instance = get_value("Zendesk instance: https://[yourZendeskInstance].zendesk.com: ", is_mandatory = True)
+
+# Load bugs from bugzilla
+print("\nLoading bugs...")
+cursor_bugs = mysql_conn.cursor()
+cursor_bugs.execute("""
+SELECT 
+b.bug_id,
+b.bug_severity,
+b.bug_status,
+b.creation_ts,
+b.short_desc,
+b.op_sys,
+b.priority,
+p.name product,
+b.rep_platform,
+b.version,
+c.name component,
+b.cf_bugtype,
+b.cf_listusers,
+b.cf_zendesk_ticket_id_text
+
+FROM bugs b, products p, components c
+
+WHERE
+b.bug_status NOT IN ('RELEASED', 'CLOSED')
+AND b.resolution IN ('')
+AND b.product_id = p.id
+AND b.component_id = c.id
+
+ORDER BY b.bug_id""")
+rows_bugs = cursor_bugs.fetchall()
+
+print("Loading android versions...")
+cursor_android_version = mysql_conn.cursor()
+cursor_android_version.execute("""
+SELECT av.bug_id, av.value
+FROM bug_cf_android_version av""")
+rows_android_version = cursor_android_version.fetchall()
+
+print("Loading attachements...")
+cursor_attachements = mysql_conn.cursor()
+cursor_attachements.execute("""
+SELECT a.bug_id, a.filename, a.description, d.thedata
+FROM attachments a, attach_data d
+WHERE a.attach_id = d.id
+ORDER BY a.bug_id""")
+rows_attachements = cursor_attachements.fetchall()
+
+print("Loading comments...")
+cursor_comments = mysql_conn.cursor()
+cursor_comments.execute("""
+SELECT c.bug_id, w.login_name, c.bug_when, c.thetext
+FROM longdescs c, profiles w
+WHERE c.who = w.userid
+ORDER BY c.comment_id""")
+rows_comments = cursor_comments.fetchall()
+
+print("\nDisconnecting from your MySQL database...")
+mysql_conn.close()
+print("Disconnected.\n")
+
+# We will store a dict with bugzilla {bug id: jira issue} to, then, add android versions, comments and attachements
+bug_id_jira_issue_dict = {}
+
+# Create JIRA issues from bugs (without comments, attachements and Android versions)
+print("Creating JIRA issue for each bug...\n")
+for row_bug in rows_bugs:
+    print("Loading bug {0} : {1}".format(row_bug[0], row_bug[4]))
+    issue_summary = '[BZ' + str(row_bug[0]) + '] ' + row_bug[4]
+    issue_description = '[CREATED]: ' + str(row_bug[3]) + '\n' + \
+                        '[Operating system]: ' + row_bug[5] + '\n' + \
+                        '[Product]: ' + row_bug[7] + '\n' + \
+                        '[Platform]: ' + row_bug[8] + '\n' + \
+                        '[Version]: ' + row_bug[9] + '\n' + \
+                        '[Android Version]: ' + ANDROID_VERSION_KEY + '\n' + \
+                        '[Component ID]: ' + row_bug[10] + '\n' + \
+                        '[Affected users]: ' + row_bug[12] + '\n' + \
+                        '[Zendesk ticket]: https://' + zendesk_instance + '.zendesk.com/agent/tickets/' + row_bug[13] + '\n' + \
+                        '[Description]:\n' + DESCRIPTION_KEY
+    issue_priority = row_bug[6].replace("Normal", "Medium").replace("---", "Medium")
+    issue_dict = {'project':jira_project, 'summary': issue_summary, 'description': issue_description, 'priority': {'name': issue_priority}, "labels": [JIRA_LABEL] }
+    issue_type = 'Story'
+    if (row_bug[11] in ['Ticket', 'Problem']):
+        issue_type = 'Bug'
+        issue_severity = row_bug[1].replace("---", "normal").replace("-", " ")
+        issue_status = row_bug[2].replace("---", "TO_CHECK").replace("-", " ").replace("_", " ").capitalize()
+        issue_dict.update({'customfield_10600': {'value': issue_severity}, 'customfield_10601': {'value': issue_status}})
+    issue_dict.update({'issuetype': {'name': issue_type}})
+    new_issue = jira.create_issue(fields=issue_dict)
+    bug_id_jira_issue_dict.update({row_bug[0]: new_issue})
+    print("Created JIRA issue https://" + jira_instance + ".atlassian.net/browse/" + new_issue.key + "\n")
+
+# Add Android versions for each issues
+print("Adding Android versions to JIRA issues...")
+# Create a dict with bug_id | android versions
+bug_id_android_versions_dict = {}
+# Loop on android versions table to fill the dict
+for row_android_version in rows_android_version:
+    value = bug_id_android_versions_dict.get(row_android_version[0])
+    if (value == None):
+        bug_id_android_versions_dict.update({row_android_version[0]: row_android_version[1]})
+    else:
+        bug_id_android_versions_dict.update({row_android_version[0]: value + ", " + row_android_version[1]})
+# Loop on each jira issue
+for bug in bug_id_jira_issue_dict:
+    if (bug not in bug_id_android_versions_dict):
+        continue
+    # Get the description from bug_id_jira_id_dict and update the android version with the one stored in bug_id_android_versions_dict
+    issue = bug_id_jira_issue_dict.get(bug)
+    description = issue.fields.description
+    description = description.replace(ANDROID_VERSION_KEY, bug_id_android_versions_dict.get(bug))
+    # push the result on jira
+    bug_id_jira_issue_dict.get(bug).update(description= description)
+    print("Updated JIRA issue https://" + jira_instance + ".atlassian.net/browse/" + issue.key + "")
+
+# Add Attachements to issues
+print("\nAdding attachements to JIRA issues...\n")
+# Loop on attachement table
+for row_attachement in rows_attachements:
+    if (row_attachement[0] not in bug_id_jira_issue_dict):
+        continue
+    issue = bug_id_jira_issue_dict.get(row_attachement[0])
+    filename = row_attachement[1]
+    description = row_attachement[2]
+    file = open('./' + filename, 'wb')
+    file.write(row_attachement[3])
+    file.close()
+    # Reopen the file in 'rb' as JIRA really want that
+    file = open('./' + filename, 'rb')
+    # Add attachement to jira
+    jira.add_attachment(issue, file, filename)
+    file.close()
+    os.remove('./' + filename)
+    comment = "Add an attached file : [^" + filename + "]\n\n" + description
+    # Add a comment in jira issue with a description of the attachement
+    jira.add_comment(issue, comment)
+    print("Added attachement " + filename + " to issue https://" + jira_instance + ".atlassian.net/browse/" + issue.key)
+
+# Add comments to issues
+print("\nAdding comments to JIRA issues...\n")
+# Create an array to list the issue who already have a description, as the first bugzilla comment will be the JIRA description
+issues_with_description = []
+# Loop on comments table
+for row_comments in rows_comments:
+    if (row_comments[0] not in bug_id_jira_issue_dict or row_comments[3] == ''):
+        continue
+    issue = bug_id_jira_issue_dict.get(row_comments[0])
+    long_comment = str(row_comments[2]) + ", by " + row_comments[1] + ":\n" + row_comments[3]
+    if (issue.key not in issues_with_description):
+        # Get the description from bug_id_jira_id_dict and update the description with the one stored in row_comments
+        description = issue.fields.description
+        description = description.replace(DESCRIPTION_KEY, long_comment)
+        # Push the result on jira
+        issue.update(description= description)
+        print("Updated JIRA issue description https://" + jira_instance + ".atlassian.net/browse/" + issue.key + "")
+        issues_with_description.append(issue.key)
+    else:
+        # Add the comment as... comment in the issue
+        jira.add_comment(issue, long_comment)
+        print("Added comment to issue https://" + jira_instance + ".atlassian.net/browse/" + issue.key)
+
+print("\nThat's all folks, keep the vibe and stay true!\nCmoaToto\n")

--- a/bugToJira.py
+++ b/bugToJira.py
@@ -32,7 +32,8 @@ def get_value(question, is_mandatory=False, default_value='', is_password=False)
 
 # Script!
 
-print("\nWelcome to this awesome script which will migrate your bugzilla tickets to your JIRA instance. please give us all your personnal informations.\n")
+print("\nWelcome to this awesome script which will migrate your bugzilla " + \
+" tickets to your JIRA instance. please give us all your personnal informations.\n")
 
 # Get Bugzilla DB info and connect
 mysql_host = get_value("MySQL host [localhost]: ", default_value='localhost')
@@ -41,7 +42,10 @@ mysql_password = get_value("MySQL password [root]: ", default_value='root', is_p
 mysql_database = get_value("MySQL database table [bugzilla]: ", default_value='bugzilla')
 
 print("\nConnecting to your MySQL database...")
-mysql_conn = mysql.connector.connect(host=mysql_host, user=mysql_user,password=mysql_password, database=mysql_database)
+mysql_conn = mysql.connector.connect(host=mysql_host,
+                                     user=mysql_user,
+                                     password=mysql_password,
+                                     database=mysql_database)
 print("Connected.\n")
 
 # Get JIRA info and connect
@@ -56,69 +60,71 @@ jira = JIRA(jira_options, basic_auth=(jira_username, jira_password))
 print("Connected.\n")
 
 # Get Zendesk instance to create cool links
-zendesk_instance = get_value("Zendesk instance: https://[yourZendeskInstance].zendesk.com: ", is_mandatory=True)
+zendesk_instance = get_value("Zendesk instance: https://[yourZendeskInstance].zendesk.com: ",
+                             is_mandatory=True)
 
 # Load bugs from bugzilla
 print("\nLoading bugs...")
 cursor_bugs = mysql_conn.cursor()
 cursor_bugs.execute("""
-SELECT 
-b.bug_id,
-b.bug_severity,
-b.bug_status,
-b.creation_ts,
-b.short_desc,
-b.op_sys,
-b.priority,
-p.name product,
-b.rep_platform,
-b.version,
-c.name component,
-b.cf_bugtype,
-b.cf_listusers,
-b.cf_zendesk_ticket_id_text
+    SELECT
+    b.bug_id,
+    b.bug_severity,
+    b.bug_status,
+    b.creation_ts,
+    b.short_desc,
+    b.op_sys,
+    b.priority,
+    p.name product,
+    b.rep_platform,
+    b.version,
+    c.name component,
+    b.cf_bugtype,
+    b.cf_listusers,
+    b.cf_zendesk_ticket_id_text
 
-FROM bugs b, products p, components c
+    FROM bugs b, products p, components c
 
-WHERE
-b.bug_status NOT IN ('RELEASED', 'CLOSED')
-AND b.resolution IN ('')
-AND b.product_id = p.id
-AND b.component_id = c.id
+    WHERE
+    b.bug_status NOT IN ('RELEASED', 'CLOSED')
+    AND b.resolution IN ('')
+    AND b.product_id = p.id
+    AND b.component_id = c.id
 
-ORDER BY b.bug_id""")
+    ORDER BY b.bug_id""")
 rows_bugs = cursor_bugs.fetchall()
 
 print("Loading android versions...")
 cursor_android_version = mysql_conn.cursor()
 cursor_android_version.execute("""
-SELECT av.bug_id, av.value
-FROM bug_cf_android_version av""")
+    SELECT av.bug_id, av.value
+    FROM bug_cf_android_version av""")
 rows_android_version = cursor_android_version.fetchall()
 
 print("Loading attachments...")
 cursor_attachments = mysql_conn.cursor()
 cursor_attachments.execute("""
-SELECT a.bug_id, a.filename, a.description, d.thedata
-FROM attachments a, attach_data d
-WHERE a.attach_id = d.id
-ORDER BY a.bug_id""")
+    SELECT a.bug_id, a.filename, a.description, d.thedata
+    FROM attachments a, attach_data d
+    WHERE a.attach_id = d.id
+    ORDER BY a.bug_id""")
 rows_attachments = cursor_attachments.fetchall()
 
 print("Loading comments...")
 cursor_comments = mysql_conn.cursor()
 cursor_comments.execute("""
-SELECT c.bug_id, w.login_name, c.bug_when, c.thetext
-FROM longdescs c, profiles w
-WHERE c.who = w.userid
-ORDER BY c.comment_id""")
+    SELECT c.bug_id, w.login_name, c.bug_when, c.thetext
+    FROM longdescs c, profiles w
+    WHERE c.who = w.userid
+    ORDER BY c.comment_id""")
 rows_comments = cursor_comments.fetchall()
 
 print("\nDisconnecting from your MySQL database...")
 mysql_conn.close()
 print("Disconnected.\n")
 
-# We will store a dict with bugzilla {bug id: jira issue} to, then, add android versions, comments and attachments
+# We will store a dict with bugzilla {bug id: jira issue} to, then, add
+# android versions, comments and attachments
 bug_id_jira_issue_dict = {}
 
 # Create JIRA issues from bugs (without comments, attachments and Android versions)
@@ -134,20 +140,30 @@ for row_bug in rows_bugs:
                         '[Android Version]: ' + ANDROID_VERSION_KEY + '\n' + \
                         '[Component ID]: ' + row_bug[10] + '\n' + \
                         '[Affected users]: ' + row_bug[12] + '\n' + \
-                        '[Zendesk ticket]: https://' + zendesk_instance + '.zendesk.com/agent/tickets/' + row_bug[13] + '\n' + \
+                        '[Zendesk ticket]: https://' + zendesk_instance + \
+                            '.zendesk.com/agent/tickets/' + row_bug[13] + '\n' + \
                         '[Description]:\n' + DESCRIPTION_KEY
     issue_priority = row_bug[6].replace("Normal", "Medium").replace("---", "Medium")
-    issue_dict = {'project':jira_project, 'summary': issue_summary, 'description': issue_description, 'priority': {'name': issue_priority}, "labels": [JIRA_LABEL]}
+    issue_dict = {'project':jira_project,
+                  'summary': issue_summary,
+                  'description': issue_description,
+                  'priority': {'name': issue_priority},
+                  "labels": [JIRA_LABEL]}
     issue_type = 'Story'
     if row_bug[11] in ['Ticket', 'Problem']:
         issue_type = 'Bug'
         issue_severity = row_bug[1].replace("---", "normal").replace("-", " ")
-        issue_status = row_bug[2].replace("---", "TO_CHECK").replace("-", " ").replace("_", " ").capitalize()
-        issue_dict.update({'customfield_10600': {'value': issue_severity}, 'customfield_10601': {'value': issue_status}})
+        issue_status = row_bug[2].replace("---", "TO_CHECK")
+                                 .replace("-", " ")
+                                 .replace("_", " ")
+                                 .capitalize()
+        issue_dict.update({'customfield_10600': {'value': issue_severity},
+                           'customfield_10601': {'value': issue_status}})
     issue_dict.update({'issuetype': {'name': issue_type}})
     new_issue = jira.create_issue(fields=issue_dict)
     bug_id_jira_issue_dict.update({row_bug[0]: new_issue})
-    print("Created JIRA issue https://" + jira_instance + ".atlassian.net/browse/" + new_issue.key + "\n")
+    print("Created JIRA issue https://" + jira_instance + \
+          ".atlassian.net/browse/" + new_issue.key + "\n")
 
 # Add Android versions for each issues
 print("Adding Android versions to JIRA issues...")
@@ -164,7 +180,8 @@ for row_android_version in rows_android_version:
 for bug in bug_id_jira_issue_dict:
     if bug not in bug_id_android_versions_dict:
         continue
-    # Get the description from bug_id_jira_id_dict and update the android version with the one stored in bug_id_android_versions_dict
+    # Get the description from bug_id_jira_id_dict and update the android
+    # version with the one stored in bug_id_android_versions_dict
     issue = bug_id_jira_issue_dict.get(bug)
     description = issue.fields.description
     description = description.replace(ANDROID_VERSION_KEY, bug_id_android_versions_dict.get(bug))
@@ -182,7 +199,7 @@ for row_attachment in rows_attachments:
     filename = row_attachment[1]
     description = row_attachment[2]
     attachment_file = open('./' + filename, 'wb')
-    attachment_file.write(row_attachment[3])
+    attachment_file.write(row_attachment[3]) you
     attachment_file.close()
     # Reopen the file in 'rb' as JIRA really want that
     attachment_file = open('./' + filename, 'rb')
@@ -193,11 +210,13 @@ for row_attachment in rows_attachments:
     comment = "Add an attached file : [^" + filename + "]\n\n" + description
     # Add a comment in jira issue with a description of the attachment
     jira.add_comment(issue, comment)
-    print("Added attachment " + filename + " to issue https://" + jira_instance + ".atlassian.net/browse/" + issue.key)
+    print("Added attachment " + filename + " to issue https://" + \
+           jira_instance + ".atlassian.net/browse/" + issue.key)
 
 # Add comments to issues
 print("\nAdding comments to JIRA issues...\n")
-# Create an array to list the issue who already have a description, as the first bugzilla comment will be the JIRA description
+# Create an array to list the issue who already have a description, as
+# the first bugzilla comment will be the JIRA description
 issues_with_description = []
 # Loop on comments table
 for row_comments in rows_comments:
@@ -206,16 +225,19 @@ for row_comments in rows_comments:
     issue = bug_id_jira_issue_dict.get(row_comments[0])
     long_comment = str(row_comments[2]) + ", by " + row_comments[1] + ":\n" + row_comments[3]
     if issue.key not in issues_with_description:
-        # Get the description from bug_id_jira_id_dict and update the description with the one stored in row_comments
+        # Get the description from bug_id_jira_id_dict and update the
+        # description with the one stored in row_comments
         description = issue.fields.description
         description = description.replace(DESCRIPTION_KEY, long_comment)
         # Push the result on jira
         issue.update(description= description)
-        print("Updated JIRA issue description https://" + jira_instance + ".atlassian.net/browse/" + issue.key + "")
+        print("Updated JIRA issue description https://" + jira_instance + \
+              ".atlassian.net/browse/" + issue.key + "")
         issues_with_description.append(issue.key)
     else:
         # Add the comment as... comment in the issue
         jira.add_comment(issue, long_comment)
-        print("Added comment to issue https://" + jira_instance + ".atlassian.net/browse/" + issue.key)
+        print("Added comment to issue https://" + jira_instance + \
+              ".atlassian.net/browse/" + issue.key)
 
 print("\nThat's all folks, keep the vibe and stay true!\nCmoaToto\n")

--- a/bugToJira.py
+++ b/bugToJira.py
@@ -96,14 +96,14 @@ SELECT av.bug_id, av.value
 FROM bug_cf_android_version av""")
 rows_android_version = cursor_android_version.fetchall()
 
-print("Loading attachements...")
-cursor_attachements = mysql_conn.cursor()
-cursor_attachements.execute("""
+print("Loading attachments...")
+cursor_attachments = mysql_conn.cursor()
+cursor_attachments.execute("""
 SELECT a.bug_id, a.filename, a.description, d.thedata
 FROM attachments a, attach_data d
 WHERE a.attach_id = d.id
 ORDER BY a.bug_id""")
-rows_attachements = cursor_attachements.fetchall()
+rows_attachments = cursor_attachments.fetchall()
 
 print("Loading comments...")
 cursor_comments = mysql_conn.cursor()
@@ -118,10 +118,10 @@ print("\nDisconnecting from your MySQL database...")
 mysql_conn.close()
 print("Disconnected.\n")
 
-# We will store a dict with bugzilla {bug id: jira issue} to, then, add android versions, comments and attachements
+# We will store a dict with bugzilla {bug id: jira issue} to, then, add android versions, comments and attachments
 bug_id_jira_issue_dict = {}
 
-# Create JIRA issues from bugs (without comments, attachements and Android versions)
+# Create JIRA issues from bugs (without comments, attachments and Android versions)
 print("Creating JIRA issue for each bug...\n")
 for row_bug in rows_bugs:
     print("Loading bug {0} : {1}".format(row_bug[0], row_bug[4]))
@@ -172,28 +172,28 @@ for bug in bug_id_jira_issue_dict:
     bug_id_jira_issue_dict.get(bug).update(description= description)
     print("Updated JIRA issue https://" + jira_instance + ".atlassian.net/browse/" + issue.key + "")
 
-# Add Attachements to issues
-print("\nAdding attachements to JIRA issues...\n")
-# Loop on attachement table
-for row_attachement in rows_attachements:
-    if row_attachement[0] not in bug_id_jira_issue_dict:
+# Add Attachments to issues
+print("\nAdding attachments to JIRA issues...\n")
+# Loop on attachment table
+for row_attachment in rows_attachments:
+    if row_attachment[0] not in bug_id_jira_issue_dict:
         continue
-    issue = bug_id_jira_issue_dict.get(row_attachement[0])
-    filename = row_attachement[1]
-    description = row_attachement[2]
-    file = open('./' + filename, 'wb')
-    file.write(row_attachement[3])
-    file.close()
+    issue = bug_id_jira_issue_dict.get(row_attachment[0])
+    filename = row_attachment[1]
+    description = row_attachment[2]
+    attachment_file = open('./' + filename, 'wb')
+    attachment_file.write(row_attachment[3])
+    attachment_file.close()
     # Reopen the file in 'rb' as JIRA really want that
-    file = open('./' + filename, 'rb')
-    # Add attachement to jira
-    jira.add_attachment(issue, file, filename)
-    file.close()
+    attachment_file = open('./' + filename, 'rb')
+    # Add attachment to jira
+    jira.add_attachment(issue, attachment_file, filename)
+    attachment_file.close()
     os.remove('./' + filename)
     comment = "Add an attached file : [^" + filename + "]\n\n" + description
-    # Add a comment in jira issue with a description of the attachement
+    # Add a comment in jira issue with a description of the attachment
     jira.add_comment(issue, comment)
-    print("Added attachement " + filename + " to issue https://" + jira_instance + ".atlassian.net/browse/" + issue.key)
+    print("Added attachment " + filename + " to issue https://" + jira_instance + ".atlassian.net/browse/" + issue.key)
 
 # Add comments to issues
 print("\nAdding comments to JIRA issues...\n")

--- a/bugToJira.py
+++ b/bugToJira.py
@@ -174,9 +174,9 @@ for row_bug in rows_bugs:
                                  .capitalize()
         issue_dict.update({'customfield_10600': {'value': issue_severity},
                            'customfield_10601': {'value': issue_status}})
-    issue_dict.update({'issuetype': {'name': issue_type}})
+    issue_dict['issuetype'] = {'name': issue_type}
     new_issue = jira.create_issue(fields=issue_dict)
-    bug_id_jira_issue_dict.update({row_bug[0]: new_issue})
+    bug_id_jira_issue_dict[row_bug[0]] = new_issue
     print("Created JIRA issue https://" + jira_instance + \
           ".atlassian.net/browse/" + new_issue.key + "\n")
 
@@ -187,10 +187,10 @@ bug_id_android_versions_dict = {}
 # Loop on android versions table to fill the dict
 for row_android_version in rows_android_version:
     value = bug_id_android_versions_dict.get(row_android_version[0])
-    if value == None:
-        bug_id_android_versions_dict.update({row_android_version[0]: row_android_version[1]})
+    if value is None:
+        bug_id_android_versions_dict[row_android_version[0]] = row_android_version[1]
     else:
-        bug_id_android_versions_dict.update({row_android_version[0]: value + ", " + row_android_version[1]})
+        bug_id_android_versions_dict[row_android_version[0]] = value + ", " + row_android_version[1]
 # Loop on each jira issue
 for bug in bug_id_jira_issue_dict:
     if bug not in bug_id_android_versions_dict:


### PR DESCRIPTION
You like comments ? everything is in the Readme. Let me copy paste it so you have it beautiful!
# bugzilla_to_jira

Python script to migrate your Bugzilla ticket to Jira
### Installation

Clone the repo, or download the raw bugToJira.py

Install JIRA python library
`$ sudo pip install jira`

Install MySQL python library:
- For Fedora:

```
$ sudo yum install mysql-connector-python
```
- For Ubuntu

```
$ sudo apt-get install python-mysqldb
```
### Usage

Run: `$ ./bugToJira.py`

No argument needed, everything will be prompt
### Real usage for your needs

This script has been created for our company instances of bugzilla an JIRA so some part must be changed when you use it:
- We use our zendesk instance name to keep our zendesk links in our jira issues
- The tables requested might change if you created personnal bugzilla fields.
- The elements of the description might change for the same reason
- If you want to use custom fields in jira to store some values, you'll have to set them up like it is in the script
  `issue_dict.update({'customfield_10600': {'value': issue_severity}, 'customfield_10601': {'value': issue_status}})`
- The `Android Version` we use in our script is a kind of a trick to keep a n to n table in a list, in the description.
### All `bugToJira.py` comments in a row

```
# Functions!

# Get a value from the user

# Script!

# Get Bugzilla DB info and connect
# Get JIRA info and connect
# Get Zendesk instance to create cool links

# Load bugs from bugzilla
# We will store a dict with bugzilla {bug id: jira issue} to, then, add android versions, comments and attachments

# Create JIRA issues from bugs (without comments, attachments and Android versions)

# Add Android versions for each issues
# Create a dict with bug_id | android versions
# Loop on android versions table to fill the dict
# Loop on each jira issue
    # Get the description from bug_id_jira_id_dict and update the android version with the one stored in bug_id_android_versions_dict
    # push the result on jira

# Add attachments to issues
# Loop on attachment table
    # Reopen the file in 'rb' as JIRA really want that
    # Add attachment to jira
    # Add a comment in jira issue with a description of the attachment

# Add comments to issues
# Create an array to list the issue who already have a description, as the first bugzilla comment will be the JIRA description
# Loop on comments table
    # If first comment
        # Get the description from bug_id_jira_id_dict and update the description with the one stored in row_comments
        # Push the result on jira
    # Else
        # Add the comment as... comment in the issue
```
